### PR TITLE
Don't run encodeURIComponent on Invite parameters

### DIFF
--- a/webapp.js
+++ b/webapp.js
@@ -51,7 +51,7 @@ const bootstrap = () => {
       }
       let query = ''
       for (let key in params) {
-        query += encodeURIComponent(key) + '=' + encodeURIComponent(params[key]) + '&'
+        query += encodeURIComponent(key) + '=' + params[key] + '&'
       }
       fullUrl = accessIp + '/#/join?' + query
       data.fullUrl = fullUrl


### PR DESCRIPTION
Seems like encoded server URLs result in an invalid Invite URL. By making this change, I was able to generate valid Invite URLs, even when the room had special characters in the password/room name. I am not sure what the original intent of this code was, or if I am missing something. I did test it in my scenario, and it worked.