### PR TITLE
Allow flexable height for server browser container

### DIFF
--- a/src/components/application/plexbrowser.vue
+++ b/src/components/application/plexbrowser.vue
@@ -152,7 +152,9 @@
               <v-card
                 class="white--text"
                 horizontal
+                height="10em"
                 style="cursor: pointer; z-index: 0; background: rgba(0,0,0,0.4);"
+                :title="server.name"
               >
                 <v-container fill-height>
                   <v-layout row justify-center align-center>
@@ -160,8 +162,8 @@
                       <v-card-media :src="logos.plex.standard" height="110px" contain></v-card-media>
                     </v-flex>
                     <v-flex xs8 class="pl-2">
-                      <div style="overflow: hidden">
-                        <h1>{{ server.name }}</h1>
+                      <div>
+                        <h1 style="white-space: nowrap; text-overflow: ellipsis; overflow: hidden;">{{ server.name }}</h1>
                         <h4 style="opacity: 0.9">v{{ server.productVersion }}</h4>
                         <div>Owned by {{ ownerOfServer(server) }}</div>
                         <div v-if="!isConnectable(server)" class="red--text">Unable to connect</div>

--- a/src/components/application/plexbrowser.vue
+++ b/src/components/application/plexbrowser.vue
@@ -152,7 +152,6 @@
               <v-card
                 class="white--text"
                 horizontal
-                height="10em"
                 style="cursor: pointer; z-index: 0; background: rgba(0,0,0,0.4);"
               >
                 <v-container fill-height>


### PR DESCRIPTION
The 10em height attribute was forcing the container height for the
server browsing components to be 10em. This meant that in the case of long server
names, the text would grow outside of the container. By removing the
10em height attribute, we can flexibly grow/shrink the container to the 
text height.

**Before:**
<img width="1440" alt="Screen Shot 2019-04-24 at 5 45 42 PM" src="https://user-images.githubusercontent.com/14287381/56699184-1ee84700-66ba-11e9-816e-3dfb48f24f53.png">
**After:**
<img width="1440" alt="Screen Shot 2019-04-24 at 5 46 16 PM" src="https://user-images.githubusercontent.com/14287381/56699189-26a7eb80-66ba-11e9-873a-da473dc1f318.png">