### PR TITLE
Improve messages on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10767,9 +10767,9 @@
       }
     },
     "vuetify": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.1.4.tgz",
-      "integrity": "sha512-BJhkFv2pVDQTT4N8WhIwicyVFwA0fjsIV771+eoR0mLFtVk9beM5Ii0L4HcSQIIVepmWzuLsEbqmmqCdOkw5og=="
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.5.14.tgz",
+      "integrity": "sha512-7iM+TfghR/wu/Gl+k37lKr0N8Ddr6SxzqHtoK1dIyHgCH6SJRkpaXPw2MC5/FsAg9aUDJbYNWrzSeu5eHw+Q/w=="
     },
     "vuex": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4524,6 +4524,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fscreen": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.0.2.tgz",
+      "integrity": "sha1-xMUdltgZ11oZ1yjg30Rfm+m7mE8="
+    },
     "fsevents": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.18.2",
     "cors": "^2.8.3",
     "express": "^4.16.3",
+    "fscreen": "^1.0.2",
     "git-rev-sync": "^1.12.0",
     "jsonfile": "^4.0.0",
     "moment": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "videojs-contrib-hls": "^5.5.2",
     "vue": "^2.5.2",
     "vue-router": "^2.3.1",
-    "vuetify": "^1.1.4",
+    "vuetify": "^1.5.14",
     "vuex": "^2.3.1",
     "waterline": "^0.13.6",
     "waterline-mysql": "^0.6.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -50,13 +50,13 @@
           </v-container>
         </v-flex>
         <div v-else :style="paddingStyle">
-          <v-breadcrumbs v-if="crumbs && crumbs.length > 0" class="text-xs-left" style="justify-content: left">
-            <v-icon slot="divider">chevron_right</v-icon>
-            <v-breadcrumbs-item
-              v-for="item in crumbs" :key="item.text" :to="item.to" :exact="true"
->
-              {{ item.text }}
-            </v-breadcrumbs-item>
+          <v-breadcrumbs :items="crumbs" v-if="crumbs && crumbs.length > 0" class="text-xs-left" style="justify-content: left">
+              <template v-slot:divider>
+                <v-icon>chevron_right</v-icon>
+              </template>
+              <template v-slot:item="props">
+                <v-breadcrumbs-item :to="props.item.to" :exact="true">{{ props.item.text }}</v-breadcrumbs-item>
+              </template>
           </v-breadcrumbs>
           <router-view></router-view>
         </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,11 +9,11 @@
       app
       persistent
       v-model="drawerRight" right enable-resize-watcher
->
+    >
       <drawerright></drawerright>
     </v-navigation-drawer>
 
-    <v-toolbar app fixed style="z-index: 5">
+    <v-toolbar app fixed scroll-off-screen :scroll-threshold="1" :manual-scroll="appIsFullscreen" style="z-index: 5">
       <v-toolbar-side-icon @click="drawer = !drawer"></v-toolbar-side-icon>
       <a href="https://synclounge.tv" target="_blank">
         <img class="ma-1 hidden-xs-only" style="height: 42px; width: auto; vertical-align: middle" v-bind:src="logos.light.long" />
@@ -23,6 +23,7 @@
       <v-spacer></v-spacer>
       <v-toolbar-items>
         <v-btn color="primary" dark raised v-if="shortUrl != null" v-clipboard="shortUrl" @success="sendNotification()">Invite</v-btn>
+        <v-btn dark @click="goFullscreen" class="hidden-lg-and-up" icon><v-icon>fullscreen</v-icon></v-btn>
         <v-btn small tag="a" class="hidden-sm-and-down" flat v-for="item in links" :key="item.title" :href="item.href" :target="item.target">{{ item.title }}</v-btn>
         <v-btn small tag="a" class="hidden-sm-and-down" flat @click="donateDialog = true">Donate ♥</v-btn>
         <v-icon v-if="showRightDrawerButton" @click="toggleDrawerRight" class="clickable">{{ drawerRight ? 'last_page' : 'first_page' }}</v-icon>
@@ -79,6 +80,8 @@
 <script>
 // Custom css
 import './assets/css/style.css';
+
+import fscreen from 'fscreen';
 
 import drawerright from './sidebar';
 import leftsidebar from './leftsidebar';
@@ -137,7 +140,7 @@ export default {
           href: 'https://discord.gg/fKQB3yt',
         },
       ],
-
+      appIsFullscreen: false,
     };
   },
   methods: {
@@ -148,6 +151,9 @@ export default {
     toggleDrawerRight() {
       this.drawerRight = !this.drawerRight;
     },
+    goFullscreen() {
+      fscreen.requestFullscreen(document.body);
+    }
   },
   async mounted() {
     try {
@@ -216,6 +222,12 @@ export default {
         });
       }
     }
+
+    fscreen.addEventListener('fullscreenchange', () => {
+      const isFullscreen = fscreen.fullscreenElement !== null;
+      this.appIsFullscreen = isFullscreen;
+      document.body.classList.toggle('is-fullscreen', isFullscreen);
+    });
 
     this.loading = false;
   },

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -318,6 +318,13 @@ video.vjs-tech,
   padding-top: 0px;
 }
 
+/* Make player 16x9 relative to viewport width on mobile */
+@media screen and (max-width: 1264px) {
+  .ptplayer .video-js {
+    height: calc(0.5625 * 100vw);
+  }
+}
+
 .ptplayer .vjs_video_1177-dimensions.vjs-fluid {
   padding-top: 0;
 }

--- a/src/components/application/plexbrowser.vue
+++ b/src/components/application/plexbrowser.vue
@@ -159,7 +159,7 @@
                 <v-container fill-height>
                   <v-layout row justify-center align-center>
                     <v-flex xs4>
-                      <v-card-media :src="logos.plex.standard" height="110px" contain></v-card-media>
+                      <v-img :src="logos.plex.standard" height="110px" contain></v-img>
                     </v-flex>
                     <v-flex xs8 class="pl-2">
                       <div>

--- a/src/components/application/plexbrowser/plexcontent.vue
+++ b/src/components/application/plexbrowser/plexcontent.vue
@@ -13,11 +13,11 @@
                 <v-flex xs12 md3>
                   <v-layout row wrap>
                     <v-flex md12 class="pa-2">
-                      <v-card-media
+                      <v-img
                         :src="thumb"
                         height="30vh"
                         contain
-                      ></v-card-media>
+                      ></v-img>
                     </v-flex>
                     <v-flex xs8 md12 class="text-xs-center hidden-sm-and-down ">
                       <div v-if="playable">

--- a/src/components/application/plexbrowser/plexseason.vue
+++ b/src/components/application/plexbrowser/plexseason.vue
@@ -11,12 +11,12 @@
             <v-container style="background: rgba(0, 0, 0, .6);"  class="pa-0 ma-0" fluid grid-list-lg>
               <v-layout row style="height:100%">
                 <v-flex xs12 md3 class="hidden-sm-and-down">
-                  <v-card-media
+                  <v-img
                     :src="getThumb"
                     class="ma-0 pa-0"
                     height="25em"
                     contain
-                  ></v-card-media>
+                  ></v-img>
                 </v-flex>
                 <v-flex xs12 md9 style="position:relative" class="ma-2">
                   <div>

--- a/src/components/application/plexbrowser/plexseries.vue
+++ b/src/components/application/plexbrowser/plexseries.vue
@@ -11,12 +11,12 @@
           <v-container style="background:rgba(0,0,0,0.6)" class="pa-3 ma-0" fluid grid-list-lg>
             <v-layout row style="height:100%">
               <v-flex xs12 md3 class="hidden-sm-and-down">
-                <v-card-media
+                <v-img
                   :src="thumb"
                   class="ma-0 pa-0 hidden-sm-and-down"
                   height="25em"
                   contain
-                ></v-card-media>
+                ></v-img>
               </v-flex>
               <v-flex xs12 md9 class="ma-2">
                 <div>

--- a/src/components/application/plexbrowser/plexthumb.vue
+++ b/src/components/application/plexbrowser/plexthumb.vue
@@ -2,7 +2,7 @@
   <div class="portrait" ref="root" style="cursor: pointer" @mouseover="hovering = true" @mouseout="hovering = false">
     <router-link :to="link">
       <v-card  flat v-on:click.native="emitContentClicked(content)" class="grey darken-4 elevation-20" style="border-radius: 0px !important">
-        <v-card-media
+        <v-img
           data-tilt
           class="white--text"
           style="position:relative"
@@ -37,7 +37,7 @@
               </v-flex>
             </v-layout>
           </v-container>
-        </v-card-media>
+        </v-img>
       </v-card>
       <v-layout align-end row wrap class="text-xs-left pa-1 white--text" style="max-width: 100%">
         <v-flex xs12 v-if="!bottomOnly" style="max-width: 100%">

--- a/src/components/application/ptplayer.vue
+++ b/src/components/application/ptplayer.vue
@@ -57,7 +57,7 @@
         </transition>
       </div>
       <div class="messages-wrapper" v-if="$vuetify.breakpoint.mdAndDown">
-        <messages :ptRoom="'room'"></messages>
+        <messages></messages>
       </div>
       <v-dialog v-model="dialog" width="350">
         <v-card>

--- a/src/components/application/ptplayer.vue
+++ b/src/components/application/ptplayer.vue
@@ -14,48 +14,51 @@
         :initialOffset="offset"
         :createdAt="playerCreatedAt"
       ></videoplayer>
-      <div v-if="playingMetadata && chosenServer">
-        <transition name="fade">
-          <div v-show="hovered">
-            <v-layout row wrap style="position: absolute; top: 0; left: 0; z-index: 2" class="pa-3 hidden-xs-only">
-              <img :src="thumbUrl" class="elevation-20" style="height: 80px; width: auto; vertical-align: middle; margin-left: auto; margin-right: auto;" />
-              <v-flex class="pl-3">
-                <v-container class="pa-0" fill-height>
-                  <v-layout column wrap justify-space-apart>
-                    <v-flex>
-                      <h1>{{ getTitle(playingMetadata) }}</h1>
-                    </v-flex>
-                    <v-flex>
-                      <h3>{{ getUnder(playingMetadata) }}</h3>
-                    </v-flex>
-                    <v-flex>
-                      <h5>Playing from {{ chosenServer.name  }}</h5>
-                    </v-flex>
-                  </v-layout>
-                </v-container>
-              </v-flex>
-            </v-layout>
-            <v-layout row wrap style="position: absolute; top: 0; right: 0; z-index: 2" class="pa-3 hidden-xs-only">
-              <v-flex class="text-xs-right pa-1">
-                <div class="hidden-xs-only">
-                  <v-tooltip bottom color="accent" v-if="me && me.role !== 'host'">
-                    <v-icon slot="activator" color="white" class="clickable" :disabled="manualSyncQueued" v-on:click="doManualSync">compare_arrows</v-icon>
-                    Manual Sync
-                  </v-tooltip>
-                  <v-icon slot="activator" color="white" class="clickable pl-3" v-on:click="dialog = !dialog">settings</v-icon>
-                  <router-link to="/browse"  slot="activator">
-                    <v-icon color="white" class="pl-3" v-on:click.native="stopPlayback()">close</v-icon>
-                  </router-link>
-                </div>
-              </v-flex>
-            </v-layout>
-            <v-layout row wrap class="hoverBar" style="height: 120px; width: 100%; pointer-events: none; position: absolute; top: 0;">
-              <v-flex xs12>
-              </v-flex>
-            </v-layout>
-          </div>
-        </transition>
-      </div>
+    </div>
+    <div v-if="playingMetadata && chosenServer">
+      <transition name="fade">
+        <div v-show="hovered">
+          <v-layout row wrap style="position: absolute; top: 0; left: 0; z-index: 2" class="pa-3 hidden-xs-only">
+            <img :src="thumbUrl" class="elevation-20" style="height: 80px; width: auto; vertical-align: middle; margin-left: auto; margin-right: auto;" />
+            <v-flex class="pl-3">
+              <v-container class="pa-0" fill-height>
+                <v-layout column wrap justify-space-apart>
+                  <v-flex>
+                    <h1>{{ getTitle(playingMetadata) }}</h1>
+                  </v-flex>
+                  <v-flex>
+                    <h3>{{ getUnder(playingMetadata) }}</h3>
+                  </v-flex>
+                  <v-flex>
+                    <h5>Playing from {{ chosenServer.name  }}</h5>
+                  </v-flex>
+                </v-layout>
+              </v-container>
+            </v-flex>
+          </v-layout>
+          <v-layout row wrap style="position: absolute; top: 0; right: 0; z-index: 2" class="pa-3 hidden-xs-only">
+            <v-flex class="text-xs-right pa-1">
+              <div class="hidden-xs-only">
+                <v-tooltip bottom color="accent" v-if="me && me.role !== 'host'">
+                  <v-icon slot="activator" color="white" class="clickable" :disabled="manualSyncQueued" v-on:click="doManualSync">compare_arrows</v-icon>
+                  Manual Sync
+                </v-tooltip>
+                <v-icon slot="activator" color="white" class="clickable pl-3" v-on:click="dialog = !dialog">settings</v-icon>
+                <router-link to="/browse"  slot="activator">
+                  <v-icon color="white" class="pl-3" v-on:click.native="stopPlayback()">close</v-icon>
+                </router-link>
+              </div>
+            </v-flex>
+          </v-layout>
+          <v-layout row wrap class="hoverBar" style="height: 120px; width: 100%; pointer-events: none; position: absolute; top: 0;">
+            <v-flex xs12>
+            </v-flex>
+          </v-layout>
+        </div>
+      </transition>
+    </div>
+    <div class="messages-wrapper" v-if="$vuetify.breakpoint.mdAndDown">
+      <messages :ptRoom="'room'"></messages>
     </div>
     <v-dialog v-model="dialog" width="350">
       <v-card>
@@ -106,9 +109,9 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
-    <v-layout v-if="playingMetadata && chosenServer" justify-center align-center row class="pa-3 hidden-sm-and-up">
+    <v-layout v-if="playingMetadata && chosenServer" justify-center row class="pa-3 hidden-sm-and-up">
       <v-flex xs12>
-        <v-layout row wrap align-center justify-start>
+        <v-layout row wrap>
           <img :src="thumbUrl" class="elevation-20" style="height: 80px; width: auto; vertical-align: middle; margin-left: auto; margin-right: auto" />
           <v-flex class="pl-2">
             <v-container class="pa-0" fill-height>
@@ -144,8 +147,18 @@
   </div>
 </template>
 
+<style scoped>
+  .messages-wrapper {
+    height: calc(100vh - (0.5625 * 100vw) - 150px);
+  }
+  .is-fullscreen .messages-wrapper {
+    height: calc(100vh - (0.5625 * 100vw));
+  }
+</style>
+
 <script>
 import videoplayer from './ptplayer/videoplayer.vue';
+import messages from '@/components/messages';
 
 const plexthumb = require('./plexbrowser/plexthumb.vue');
 
@@ -155,7 +168,7 @@ const parseXMLString = require('xml2js').parseString;
 export default {
   name: 'ptplayer',
   components: {
-    videoplayer, plexthumb,
+    videoplayer, plexthumb, messages,
   },
   mounted() {
     // Check if we have params

--- a/src/components/application/ptplayer/videoplayer.vue
+++ b/src/components/application/ptplayer/videoplayer.vue
@@ -18,7 +18,7 @@
       @statechanged="playerStateChanged($event)"
 
       @ready="playerReadied"
-      style="background-color:transparent !important; min-height: 75vh"
+      style="background-color:transparent !important;"
       class="ptplayer"
 >
     </video-player>

--- a/src/components/message.vue
+++ b/src/components/message.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-flex align-center xs12 class="pb-1">
+    <v-layout row wrap justify-start>
+      <v-flex xs3 class="text-xs-center">
+        <img :src="message.user.thumb || message.user.avatarUrl" style="width: 36px; height: 36px; border-radius: 50%" />
+      </v-flex>
+      <v-flex xs9 class="pr-2">
+        <v-layout row wrap>
+          <v-flex><b style="opacity:1;font-size:80%; float:left"> {{ message.user.username }}</b></v-flex>
+          <v-flex><span style="opacity:0.6;font-size:60%; float:right"> {{ message.time}}</span></v-flex>
+          <v-flex xs12>
+            <div style="opacity:0.8;color:white;font-size:90%; max-width: 100%; word-wrap: break-word"> {{ message.msg }}</div>
+          </v-flex>
+        </v-layout>
+      </v-flex>
+    </v-layout>
+    <v-layout row class="pt-1">
+      <v-divider style="opacity: 0.6"></v-divider>
+    </v-layout>
+  </v-flex>
+</template>
+
+<script>
+export default {
+  props: ['message'],
+  methods: {
+  }
+}
+</script>
+

--- a/src/components/messages.vue
+++ b/src/components/messages.vue
@@ -10,7 +10,7 @@
     <v-flex xs12>
       <v-text-field
         prepend-icon="message"
-        :label="'Send a message to ' + '#' + ptRoom"
+        :label="chatboxLabel"
         hide-details
         single-line
         class="ma-0 ml-1 pr-1 wideinput"
@@ -32,7 +32,6 @@ export default {
   components: {
     message
   },
-  props: ['ptRoom'],
   data() {
     return {
       messageToBeSent: '',
@@ -54,8 +53,8 @@ export default {
     messages() {
       return this.$store.getters.getMessages;
     },
-    chatBoxMessage() {
-      return `Message ${this.$store.getters.getRoom}`;
+    chatboxLabel() {
+      return `Send a message to #${this.$store.getters.getRoom}`;
     },
   },
   methods: {

--- a/src/components/messages.vue
+++ b/src/components/messages.vue
@@ -1,0 +1,77 @@
+<template>
+  <v-layout row wrap style="height: 100%;">
+    <v-flex xs12 style="height: calc(100% - 96px)">
+      <v-divider class="hidden-md-and-down"></v-divider>
+      <v-layout row wrap id="chatbox" v-if="messages.length > 0" style="max-height: 100%; overflow-y: scroll">
+        <message :message="msg" :id="getMsgId(msg)" v-for="(msg, index) in messages" :key="index"></message>
+      </v-layout>
+      <v-subheader v-else>Say something to the room down below :)</v-subheader>
+    </v-flex>
+    <v-flex xs12>
+      <v-text-field
+        prepend-icon="message"
+        :label="'Send a message to ' + '#' + ptRoom"
+        hide-details
+        single-line
+        class="ma-0 ml-1 pr-1 wideinput"
+        v-on:keyup.enter.native="sendMessage()"
+        v-model="messageToBeSent"
+      ></v-text-field>
+      <v-btn block color="primary" @click="sendMessage()" :disabled="messageToBeSent.length === 0">Send<v-icon right>send</v-icon></v-btn>
+    </v-flex>
+  </v-layout>    
+</template>
+
+<script>
+import message from '@/components/message';
+import fscreen from 'fscreen';
+
+import { mapActions, mapGetters } from 'vuex';
+
+export default {
+  components: {
+    message
+  },
+  props: ['ptRoom'],
+  data() {
+    return {
+      messageToBeSent: '',
+    }
+  },
+  watch: {
+    messages() {
+      const options = {
+        container: '#chatbox',
+        easing: 'linear',
+        duration: 1,
+        cancelable: false,
+      };
+      console.info(this.$vuetify.breakpoint)
+      this.$scrollTo('#lastMessage', 5, options);
+    },
+  },
+  computed: {
+    messages() {
+      return this.$store.getters.getMessages;
+    },
+    chatBoxMessage() {
+      return `Message ${this.$store.getters.getRoom}`;
+    },
+  },
+  methods: {
+    getMsgId(msg) {
+      if (this.messages && msg === this.messages[this.messages.length - 1]) {
+        return 'lastMessage';
+      }
+    },
+    sendMessage() {
+      if (this.messageToBeSent === '') {
+        return;
+      }
+      console.log(`We should send this message: ${this.messageToBeSent}`);
+      this.$store.dispatch('sendNewMessage', this.messageToBeSent);
+      this.messageToBeSent = '';
+    },
+  },
+}
+</script>

--- a/src/sidebar.vue
+++ b/src/sidebar.vue
@@ -92,44 +92,7 @@
         </v-list>
       </v-flex>
       <v-flex xs12 style="position: relative; height: 50vh; max-height: 50vh">
-        <v-layout row wrap style="height: 100%">
-          <v-flex style="height: calc(100% - 96px); max-height: calc(100% - 96px)">
-            <v-divider></v-divider>
-            <v-subheader>Messages</v-subheader>
-            <v-layout row wrap id="chatbox" style="max-height: calc(100% - 48px); overflow-y: auto">
-              <v-flex align-center xs12 class="pb-1" :id="getMsgId(msg)" v-for="(msg, index) in messages" :key="index">
-                <v-layout row wrap justify-start>
-                  <v-flex xs3 class="text-xs-center">
-                    <img :src="msg.user.thumb || msg.user.avatarUrl" style="width: 36px; height: 36px; border-radius: 50%" />
-                  </v-flex>
-                  <v-flex xs9 class="pr-2">
-                    <v-layout row wrap>
-                      <v-flex><b style="opacity:1;font-size:80%; float:left"> {{ msg.user.username }}</b></v-flex>
-                      <v-flex><span style="opacity:0.6;font-size:60%; float:right"> {{ msg.time}}</span></v-flex>
-                      <v-flex xs12>
-                        <div style="opacity:0.8;color:white;font-size:90%; max-width: 100%; word-wrap: break-word"> {{ msg.msg }}</div>
-                      </v-flex>
-                    </v-layout>
-                  </v-flex>
-                </v-layout>
-                <v-layout row class="pt-1">
-                  <v-divider style="opacity: 0.6"></v-divider>
-                </v-layout>
-              </v-flex>
-            </v-layout>
-          </v-flex>
-          <v-flex>
-            <v-text-field
-              prepend-icon="message"
-              :label="'Send a message to ' + '#' + ptRoom"
-              hide-details
-              class="ma-0 ml-1 pr-1 wideinput"
-              v-on:keyup.enter.native="sendMessage()"
-              v-model="messageToBeSent"
-            ></v-text-field>
-            <v-btn block color="primary" @click="sendMessage()">Send</v-btn>
-          </v-flex>
-        </v-layout>
+        <messages :ptRoom="ptRoom" v-if="$vuetify.breakpoint.lgAndUp"></messages>
       </v-flex>
     </v-layout>
   </v-container>
@@ -139,12 +102,14 @@
 
 import { mapActions, mapGetters } from 'vuex';
 
+import messages from '@/components/messages.vue';
+
 export default {
   components: {
+    messages
   },
   data() {
     return {
-      messageToBeSent: '',
       lastRecievedUpdate: new Date().getTime(),
       now: new Date().getTime(),
 
@@ -157,15 +122,6 @@ export default {
     }, 250);
   },
   watch: {
-    messages() {
-      const options = {
-        container: '#chatbox',
-        easing: 'linear',
-        duration: 1,
-        cancelable: false,
-      };
-      this.$scrollTo('#lastMessage', 5, options);
-    },
     ptUsers: {
       deep: true,
       handler() {
@@ -245,9 +201,6 @@ export default {
       }
       return `${count} users`;
     },
-    chatBoxMessage() {
-      return `Message ${this.$store.getters.getRoom}`;
-    },
     playercount() {
       if (this.$store.state.plex && this.$store.state.plex.gotDevices) {
         return `(${this.$store.state.plex.clients.length})`;
@@ -268,9 +221,6 @@ export default {
     },
     serverDelay() {
       return Math.round(this.$store.state.synclounge.commands[Object.keys(this.$store.state.synclounge.commands).length - 1].difference);
-    },
-    messages() {
-      return this.$store.getters.getMessages;
     },
     difference() {
       return Math.abs(this.now - this.lastRecievedUpdate);
@@ -331,11 +281,6 @@ export default {
       }
       return perc;
     },
-    getMsgId(msg) {
-      if (this.messages && msg === this.messages[this.messages.length - 1]) {
-        return 'lastMessage';
-      }
-    },
     getCurrent(user) {
       if (isNaN(user.time) || user.time === 0 || !user.time) {
         return this.getTimeFromMs(0);
@@ -359,14 +304,6 @@ export default {
         return user.title;
       }
       return 'Nothing';
-    },
-    sendMessage() {
-      if (this.messageToBeSent === '') {
-        return;
-      }
-      console.log(`We should send this message: ${this.messageToBeSent}`);
-      this.$store.dispatch('sendNewMessage', this.messageToBeSent);
-      this.messageToBeSent = '';
     },
     playerState(user) {
       if (user.playerState) {

--- a/src/sidebar.vue
+++ b/src/sidebar.vue
@@ -92,7 +92,7 @@
         </v-list>
       </v-flex>
       <v-flex xs12 style="position: relative; height: 50vh; max-height: 50vh">
-        <messages :ptRoom="ptRoom" v-if="$vuetify.breakpoint.lgAndUp"></messages>
+        <messages v-if="$vuetify.breakpoint.lgAndUp"></messages>
       </v-flex>
     </v-layout>
   </v-container>

--- a/src/upnext.vue
+++ b/src/upnext.vue
@@ -9,11 +9,11 @@
           <v-container fluid class="pa-1">
             <v-layout row>
               <v-flex xs3 sm2>
-                <v-card-media
+                <v-img
                 :src="thumb"
                   height="125px"
                   contain
-                ></v-card-media>
+                ></v-img>
               </v-flex>
               <v-flex>
                 <div>


### PR DESCRIPTION
Summary:
- Hide toolbar when fullscreen
- Split messages into separate, reusable components
- Move messages to below video on mobile
- Size player to 16x9 on mobile
- Disable send button if no message
- Add icon to send button
- Switch message field to single-line for compactness

Notes:
I tested this on my Pixel 2 XL. Messages on mobile works best when in fullscreen, allowing for a comparable experience to rabb.it's mobile app.