### PR TITLE
Filter music libraries from list

### DIFF
--- a/src/components/application/plexbrowser/plexserver.vue
+++ b/src/components/application/plexbrowser/plexserver.vue
@@ -131,10 +131,15 @@ export default {
       return this.$store.getters.getPlex;
     },
     filteredLibraries() {
+      let data = [];
       if (this.libraries) {
-        return this.libraries.MediaContainer.Directory;
+        this.libraries.MediaContainer.Directory.forEach((library) => {
+          if(library.type != 'artist' || library.agent != 'tv.plex.agents.music') {
+            data.push(library);
+          }
+        });
       }
-      return [];
+      return data;
     },
     onDeckUpStyle() {
       if ((this.onDeckOffset + this.onDeckItemsPer) >= this.onDeck.MediaContainer.Metadata.length) {


### PR DESCRIPTION
Since music syncing isn't supported, this will filter them from the list and stop questions coming in about why syncing music won't work until it is fully supported.

Revert this filtering when issue https://github.com/samcm/synclounge/issues/47 is completed.