### PR TITLE
User defined servers list and custom server override

### DIFF
--- a/SettingsHelper.js
+++ b/SettingsHelper.js
@@ -10,6 +10,8 @@ const defaults = {
   autoJoinServer: '',
   autoJoinRoom: '',
   autoJoinPassword: '',
+  servers: '',
+  customServer: '',
 };
 
 module.exports = function () {
@@ -21,6 +23,8 @@ module.exports = function () {
     'autoJoinServer',
     'autoJoinRoom',
     'autoJoinPassword',
+    'servers',
+    'customServer',
   ];
   // Load and export our settings in preference of ENV -> args
   const output = {};

--- a/example_settings.json
+++ b/example_settings.json
@@ -5,5 +5,7 @@
     "autoJoin": false,
     "autoJoinServer": "",
     "autoJoinRoom": "",
-    "autoJoinPassword": ""
+    "autoJoinPassword": "",
+    "servers": "",
+    "customServer": ""
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -231,8 +231,8 @@ export default {
     else if (this.config && this.config.customServer) {
       servers.push(this.config.customServer);
     }
-    else if (this.config && this.settings.customServer) {
-      servers.push(this.settings.customServer);
+    else if (settings && settings.customServer) {
+      servers.push(settings.customServer);
     }
     else {
       servers.push(customServer);

--- a/src/App.vue
+++ b/src/App.vue
@@ -191,29 +191,29 @@ export default {
 
     let servers = [
       {
+        name: 'SyncLounge AU1',
         location: 'Sydney, Australia',
-        text: 'SyncLounge AU1',
-        value: 'https://v2au1.synclounge.tv/server',
-        flag: 'flags/aus.png',
+        url: 'https://v2au1.synclounge.tv/server',
+        image: 'flags/aus.png',
       },
       {
+        name: 'SyncLounge EU1',
         location: 'Amsterdam, Netherlands',
-        text: 'SyncLounge EU1',
-        value: 'https://v2eu1.synclounge.tv/server',
-        flag: 'flags/eu.png',
+        url: 'https://v2eu1.synclounge.tv/server',
+        image: 'flags/eu.png',
       },
       {
+        name: 'SyncLounge US1',
         location: 'Miami, United States',
-        text: 'SyncLounge US1',
-        value: 'https://v2us1.synclounge.tv/server',
-        flag: 'flags/usa.png',
+        url: 'https://v2us1.synclounge.tv/server',
+        image: 'flags/usa.png',
       },
     ];
     let customServer = {
+      name: 'Custom Server',
       location: 'Anywhere!',
-      text: 'Custom Server',
-      value: 'custom',
-      flag: 'synclounge-white.png',
+      url: 'custom',
+      image: 'synclounge-white.png',
     }
 
     if (this.config && this.config.servers) {
@@ -243,7 +243,7 @@ export default {
     if (servers.length == 1 && !this.$store.autoJoinServer) {
       let server = servers[0];
       this.$store.commit('SET_AUTOJOIN', true);
-      this.$store.commit('SET_AUTOJOINURL', server.value);
+      this.$store.commit('SET_AUTOJOINURL', server.url);
       if(!this.$store.autoJoinRoom && server.defaultRoom) {
         this.$store.commit('SET_AUTOJOINROOM', server.defaultRoom);
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -189,6 +189,69 @@ export default {
       }
     }
 
+    let servers = [
+      {
+        location: 'Sydney, Australia',
+        text: 'SyncLounge AU1',
+        value: 'https://v2au1.synclounge.tv/server',
+        flag: 'flags/aus.png',
+      },
+      {
+        location: 'Amsterdam, Netherlands',
+        text: 'SyncLounge EU1',
+        value: 'https://v2eu1.synclounge.tv/server',
+        flag: 'flags/eu.png',
+      },
+      {
+        location: 'Miami, United States',
+        text: 'SyncLounge US1',
+        value: 'https://v2us1.synclounge.tv/server',
+        flag: 'flags/usa.png',
+      },
+    ];
+    let customServer = {
+      location: 'Anywhere!',
+      text: 'Custom Server',
+      value: 'custom',
+      flag: 'synclounge-white.png',
+    }
+
+    if (this.config && this.config.servers) {
+      servers = this.config.servers
+      if(this.config.customServer) {
+        console.error(`'customServer' setting provided with 'servers' setting. Ignoring 'customServer' setting.`);
+      }
+    }
+    else if (settings && settings.servers) {
+      servers = settings.servers;
+      if(settings.customServer) {
+        console.error(`'customServer' setting provided with 'servers' setting. Ignoring 'customServer' setting.`);
+      }
+    }
+    else if (this.config && this.config.customServer) {
+      servers.push(this.config.customServer);
+    }
+    else if (this.config && this.settings.customServer) {
+      servers.push(this.settings.customServer);
+    }
+    else {
+      servers.push(customServer);
+    }
+
+    this.$store.commit('setSetting', ['SERVERS', servers]);
+
+    if (servers.length == 1 && !this.$store.autoJoinServer) {
+      let server = servers[0];
+      this.$store.commit('SET_AUTOJOIN', true);
+      this.$store.commit('SET_AUTOJOINURL', server.value);
+      if(!this.$store.autoJoinRoom && server.defaultRoom) {
+        this.$store.commit('SET_AUTOJOINROOM', server.defaultRoom);
+      }
+      if(!this.$store.autoJoinPassword && server.defaultPassword) {
+        this.$store.commit('SET_AUTOJOINPASSWORD', server.defaultPassword);
+      }
+    }
+
     window.EventBus.$on('notification', (msg) => {
       this.snackbarMsg = msg;
       this.snackbar = true;

--- a/src/components/application/joinroom.vue
+++ b/src/components/application/joinroom.vue
@@ -56,17 +56,17 @@
                   <v-card height="300px" style="background: #353e58">
                     <v-layout row wrap justify-center style="height: 100%">
                       <v-flex xs12 class="text-xs-center pa-2" style="height: 50%; position: relative; background: rgba(0,0,0,0.2)">
-                        <img :src="server.flag" class="flag" style="height: 50%; vertical-align: middle; max-width: 80%" />
+                        <img :src="server.image" class="flag" style="height: 50%; vertical-align: middle; max-width: 80%" />
                       </v-flex>
                       <v-flex xs12 style="height: 50%" class="text-xs-center pt-1">
-                        <h2>{{ server.text }}</h2>
+                        <h2>{{ server.name }}</h2>
                         <h4>{{ server.location }}</h4>
                         <v-btn color="primary" :disabled="connectionPending" @click="serverSelected(server)"> Connect</v-btn>
-                        <div v-if="server.value !== 'custom'">
-                          <div v-if="results[server.value]">
-                            <div v-if="results[server.value].alive">
-                              <div>Ping: <span class="thick--text" :class="connectionQualityClass(results[server.value].latency)">{{ results[server.value].latency }}ms </span></div>
-                              <div>Load: <span class="thick--text" :class="loadQualityClass(results[server.value].result)">{{ results[server.value].result || 'Unknown' }} </span></div>
+                        <div v-if="server.url !== 'custom'">
+                          <div v-if="results[server.url]">
+                            <div v-if="results[server.url].alive">
+                              <div>Ping: <span class="thick--text" :class="connectionQualityClass(results[server.url].latency)">{{ results[server.url].latency }}ms </span></div>
+                              <div>Load: <span class="thick--text" :class="loadQualityClass(results[server.url].result)">{{ results[server.url].result || 'Unknown' }} </span></div>
                             </div>
                             <div v-else class="text-xs-center red--text">
                               Unable to connect to server
@@ -82,13 +82,13 @@
                 </v-flex>
               </v-layout>
               <v-text-field
-                v-if="selectedServer.value == 'custom'"
+                v-if="selectedServer.url == 'custom'"
                 name="input-2"
                 label="Custom Server"
                 v-model="CUSTOMSERVER"
                 class="input-group pt-input"
               ></v-text-field>
-              <v-layout row wrap v-if="selectedServer.value == 'custom'">
+              <v-layout row wrap v-if="selectedServer.url == 'custom'">
                 <v-flex xs12>
                   <v-btn class="pt-orange white--text pa-0 ma-0" color="primary" primary style="width:100%" v-on:click.native="attemptConnectCustom()">Connect</v-btn>
                 </v-flex>
@@ -234,24 +234,24 @@ export default {
           this.password = this.selectedServer.defaultPassword;
         }
       }
-      if (this.selectedServer.value !== 'custom') {
+      if (this.selectedServer.url !== 'custom') {
         this.attemptConnect();
       }
     },
     async testConnections() {
       this.ptservers.map((server) => {
-        if (server.value !== 'custom') {
+        if (server.url !== 'custom') {
           const start = new Date().getTime();
-          axios.get(`${server.value}/health`)
+          axios.get(`${server.url}/health`)
             .then((res) => {
-              Vue.set(this.results, server.value, {
+              Vue.set(this.results, server.url, {
                 alive: true,
                 latency: Math.abs(start - new Date().getTime()),
                 result: res.data.load || null,
               });
             })
             .catch((e) => {
-              Vue.set(this.results, server.value, {
+              Vue.set(this.results, server.url, {
                 alive: false,
                 latency: Math.abs(start - new Date().getTime()),
                 result: null,
@@ -264,9 +264,9 @@ export default {
       // Attempt the connection
       return new Promise((resolve, reject) => {
         this.serverError = null;
-        if (this.selectedServer.value !== 'custom') {
+        if (this.selectedServer.url !== 'custom') {
           this.connectionPending = true;
-          this.$store.dispatch('socketConnect', { address: this.selectedServer.value })
+          this.$store.dispatch('socketConnect', { address: this.selectedServer.url })
             .then((result) => {
               this.connectionPending = false;
               if (result) {
@@ -283,7 +283,7 @@ export default {
             })
             .catch((e) => {
               this.connectionPending = false;
-              this.serverError = `Failed to connect to ${this.selectedServer.value}`;
+              this.serverError = `Failed to connect to ${this.selectedServer.url}`;
               reject(e);
             });
         } else {


### PR DESCRIPTION
Updates servers handling to:
- Allow users to override the custom server entry (`customServer` setting) in the default list.
Example setting:
  ```json
  "customServer": {
      "name": "Custom Server 1",
      "location": "Custom Location",
      "url": "https://mycustomserver.com/server",
      "logo": "https://mycustomserver.com/logo.png"
    }
  ```
  Result:
  ![image](https://user-images.githubusercontent.com/1524443/76433720-19a3f180-638b-11ea-8c20-1997728e8325.png)

- Allow users to set their own servers (`servers` setting)
  The servers list can also handle a default Room with or without password. If set, it will attempt to auto-join the room when the server is selected.
  Example setting:
  ```json
  "servers": [
    {
      "name": "Custom Server 1",
      "location": "Custom Location",
      "url": "https://1.mycustomserver.com/server",
      "logo": "https://mycustomserver.com/logo.png"
    },
    {
      "name": "Custom Server 2",
      "location": "Custom Location",
      "url": "https://2.mycustomserver.com/server",
      "logo": "https://mycustomserver.com/logo-2.png",
      "defaultRoom": "DefaultRoom"
    },
    {
      "name": "Custom Server 3",
      "location": "Custom Location",
      "url": "https://3.mycustomserver.com/server",
      "logo": "https://mycustomserver.com/logo-3.png",
      "defaultRoom": "DefaultRoom",
      "defaultPassword": "DefaultPassword123"
    }
  ]
  ```
  Result:
  ![image](https://user-images.githubusercontent.com/1524443/76433958-6daed600-638b-11ea-9cf6-41ea79182dbc.png)

Server list styling has also bee updated to make the UI dynamic and scale logos to fit in the card.

Notes:
- If the user sets their own server list, it will ignore the `customServer` setting.
- If the user sets `servers` to only one server, it will automatically join it. No autoJoin settings required!
- I've only tested with up to 4 servers in the list. So, styling will probably need to be updated should someone put more than 4 in the list.


This includes changes from PR https://github.com/samcm/synclounge/pull/136. So, that should be merged first or closed when this is merged.