### PR TITLE
Authentication

### DIFF
--- a/SettingsHelper.js
+++ b/SettingsHelper.js
@@ -10,6 +10,9 @@ const defaults = {
   autoJoinServer: '',
   autoJoinRoom: '',
   autoJoinPassword: '',
+  authentication: {
+    mechanism: 'none'
+  }
 };
 
 module.exports = function () {
@@ -21,6 +24,7 @@ module.exports = function () {
     'autoJoinServer',
     'autoJoinRoom',
     'autoJoinPassword',
+    'authentication'
   ];
   // Load and export our settings in preference of ENV -> args
   const output = {};

--- a/src/App.vue
+++ b/src/App.vue
@@ -172,20 +172,36 @@ export default {
         this.$store.commit('SET_AUTOJOINPASSWORD', this.$route.query.password);
       }
     }
-    else if (this.config && this.config.autoJoin) {
-      if (this.config.autoJoin === true || this.config.autoJoin === 'true') {
+    else if (this.config) {
+      if (this.config.autoJoin && (this.config.autoJoin === true || this.config.autoJoin === 'true')) {
         this.$store.commit('SET_AUTOJOIN', true);
         this.$store.commit('SET_AUTOJOINROOM', this.config.autoJoinRoom);
         this.$store.commit('SET_AUTOJOINURL', this.config.autoJoinServer);
         this.$store.commit('SET_AUTOJOINPASSWORD', this.config.autoJoinPassword);
       }
+      if(this.config.authentication) {
+        this.$store.commit('SET_AUTHENTICATION', this.config.authentication);
+      }
+      else {
+        this.$store.commit('SET_AUTHENTICATION', {
+          "type": "none"
+        });
+      }
     }
-    else if (settings && settings.autoJoin) {
-      if (settings.autoJoin === true || settings.autoJoin === 'true') {
+    else if (settings) {
+      if (settings.autoJoin && (settings.autoJoin === true || settings.autoJoin === 'true')) {
         this.$store.commit('SET_AUTOJOIN', true);
         this.$store.commit('SET_AUTOJOINROOM', settings.autoJoinRoom);
         this.$store.commit('SET_AUTOJOINURL', settings.autoJoinServer);
         this.$store.commit('SET_AUTOJOINPASSWORD', settings.autoJoinPassword);
+      }
+      if(settings.authentication) {
+        this.$store.commit('SET_AUTHENTICATION', settings.authentication);
+      }
+      else {
+        this.$store.commit('SET_AUTHENTICATION', {
+          "type": "none"
+        });
       }
     }
 
@@ -222,6 +238,7 @@ export default {
       this.$router.push('/signin');
       return;
     }
+
     if (this.$store.state.autoJoin) {
       this.$store.dispatch('autoJoin', {
         server: this.$store.state.autoJoinUrl,

--- a/src/components/signin.vue
+++ b/src/components/signin.vue
@@ -111,7 +111,6 @@ export default {
       this.$router.push('/browse');
     },
     async checkAuth(authToken) {
-      console.log('AuthToken 2: ', authToken);
       // Get stored authentication settings
       let authentication = this.$store.state.authentication;
       // Authentication defaults to false
@@ -123,7 +122,6 @@ export default {
         if(authentication.type.includes('server')) {
           // Retrieve and store the user's servers
           try {
-            console.log('AuthToken 3: ', authToken);
             await this.$store.dispatch('PLEX_GET_SERVERS', authToken);
             // Get the user object
             let user = this.$store.state.plex.user;
@@ -167,7 +165,7 @@ export default {
         };
         authenticationPassed = true;
       }
-      // Authenication mechanism isn't set. This should never happen.
+      // Authenication mechanism isn't set. This should only happen when authentication mechanism is set to 'none'.
       else {
         console.log('No authentication set');
         authenticationPassed = true;
@@ -232,14 +230,11 @@ export default {
         if (this.openedWindow) {
           this.openedWindow.close();
         }
-        console.log('AuthToken: ', result.data.authToken);
         let authenticated = await this.checkAuth(result.data.authToken);
-        console.log('authenticated: ', authenticated);
         if(authenticated) {
           window.localStorage.setItem('plexuser', JSON.stringify({ authToken: result.data.authToken }));
           await this.$store.dispatch('PLEX_LOGIN_TOKEN', result.data.authToken);
           this.token = result.data.authToken;
-          console.log('Token: ', this.token);
           this.ready = true;
 
           this.letsGo();

--- a/src/components/signin.vue
+++ b/src/components/signin.vue
@@ -19,7 +19,7 @@
         </v-layout>
         <div v-else>
           <h1 v-if="!token" :style="fontSizes.largest" class="center-text pa-4">Sign in to Plex.tv</h1>
-          <div v-if="!code">
+          <div v-if="!preAuth">
             <v-layout wrap row style="position:relative">
               <v-flex xs12 md4 offset-md4>
                 <div style="width:100%;text-align:center">
@@ -28,7 +28,7 @@
               </v-flex>
             </v-layout>
           </div>
-          <div v-if="code && !authError" class="text-xs-center">
+          <div v-if="preAuth && !authError" class="text-xs-center">
             <v-btn class="primary" @click="openPopup">Click me</v-btn>
           </div>
           <div v-if="authError" class="text-xs-center error">
@@ -71,13 +71,37 @@ export default {
         'X-Plex-Client-Identifier': this.$store.state.settings.CLIENTIDENTIFIER,
       },
       code: null,
+      preAuth: false,
       ready: false,
       openedWindow: null,
       authError: null,
     };
   },
   methods: {
-    openPopup() {
+    async openPopup() {
+      this.headers['X-Plex-Platform'] = this.sBrowser;
+      const { data } = await axios.create().post('https://plex.tv/api/v2/pins?strong=true', {}, { headers: { ...this.headers } });
+      this.code = data.code;
+      this.ticker = setInterval(async () => {
+        const result = await axios(`https://plex.tv/api/v2/pins/${data.id}`, {
+          headers: { ...this.headers },
+        });
+        if (result && result.data && result.data.authToken) {
+          if (this.openedWindow) {
+            this.openedWindow.close();
+          }
+          let authenticated = await this.checkAuth(result.data.authToken);
+          if(authenticated) {
+            await this.setAuth(result.data.authToken);
+            this.letsGo();
+          }
+          else {
+            this.authError = `You are not authorized to access this server.`;
+          }
+          clearInterval(this.ticker);
+        }
+      }, 2000);
+
       const w = 450;
       const h = 600;
       // Credit: https://stackoverflow.com/questions/4068373/center-a-popup-window-on-screen
@@ -94,11 +118,18 @@ export default {
       if (!newWindow) {
         newWindow = window.open(this.url, '_blank');
       }
+
       // Puts focus on the newWindow
       if (window.focus) {
         newWindow.focus();
       }
       this.openedWindow = newWindow;
+    },
+    async setAuth(authToken) {
+      window.localStorage.setItem('plexuser', JSON.stringify({ authToken: authToken }));
+      await this.$store.dispatch('PLEX_LOGIN_TOKEN', authToken);
+      this.token = authToken;
+      this.ready = true;
     },
     async letsGo() {
       if (this.$store.state.autoJoin) {
@@ -116,62 +147,67 @@ export default {
       // Authentication defaults to false
       let authenticationPassed = false;
 
-      // Authenication via Plex mechanism
-      if (authentication.mechanism == 'plex') {
-        // Server authorization using server data
-        if(authentication.type.includes('server')) {
-          // Retrieve and store the user's servers
-          try {
-            await this.$store.dispatch('PLEX_GET_SERVERS', authToken);
-            // Get the user object
-            let user = this.$store.state.plex.user;
-            let servers = user.servers;
+      if (authentication) {
+        // Authenication via Plex mechanism
+        if (authentication.mechanism == 'plex') {
+          // Server authorization using server data
+          if(authentication.type.includes('server')) {
+            // Retrieve and store the user's servers
+            try {
+              await this.$store.dispatch('PLEX_GET_SERVERS', authToken);
+              // Get the user object
+              let user = this.$store.state.plex.user;
+              let servers = user.servers;
 
-            // Compare servers against the authorized list
-            let serverFound = false;
-            for (const id in servers) {
-              const server = servers[id].$;
-              if(authentication.authorized.includes(server.machineIdentifier)) {
-                authenticationPassed = true;
+              // Compare servers against the authorized list
+              let serverFound = false;
+              for (const id in servers) {
+                const server = servers[id].$;
+                if(authentication.authorized.includes(server.machineIdentifier)) {
+                  authenticationPassed = true;
+                }
               }
             }
+            catch (e) {
+              console.error('An error occurred when authenticating with Plex: ', e);
+            }
           }
-          catch (e) {
-            console.error('An error occurred when authenticating with Plex: ', e);
+          // Authorization using user data
+          if (authentication.type.includes('user')) {
+            // Get the user object
+            let user = this.$store.state.plex.user;
+            // Compare the user's email against the authorized list
+            if(authentication.authorized.includes(user.email)) {
+              authenticationPassed = true;
+            }
+            // Compare the user's name against the authorized list
+            if(authentication.authorized.includes(user.username)) {
+              authenticationPassed = true;
+            }
           }
         }
-        // Authorization using user data
-        if (authentication.type.includes('user')) {
-          // Get the user object
-          let user = this.$store.state.plex.user;
-          // Compare the user's email against the authorized list
-          if(authentication.authorized.includes(user.email)) {
-            authenticationPassed = true;
-          }
-          // Compare the user's name against the authorized list
-          if(authentication.authorized.includes(user.username)) {
-            authenticationPassed = true;
-          }
+        // New authentication mechanisms can be added here
+        // else if (authentication.mechanism == 'new_mech' ) {
+        // }
+        // Authenication via an unsupported mechanism
+        else if (authentication.mechanism != 'none' ) {
+          console.error(`Invalid authentication mechanism provided: '${authentication.mechanism}'. Reverting to default.`);
+          this.$store.state.authentication = {
+            mechanism: 'none'
+          };
+          authenticationPassed = true;
         }
-      }
-      // New authentication mechanisms can be added here
-      // else if (authentication.mechanism == 'new_mech' ) {
-      // }
-      // Authenication via an unsupported mechanism
-      else if (authentication.mechanism != 'none' ) {
-        console.error(`Invalid authentication mechanism provided: '${authentication.mechanism}'. Reverting to default.`);
-        this.$store.state.authentication = {
-          mechanism: 'none'
-        };
-        authenticationPassed = true;
-      }
-      // Authenication mechanism isn't set. This should only happen when authentication mechanism is set to 'none'.
-      else {
-        console.log('No authentication set');
-        authenticationPassed = true;
-      }
+        // Authenication mechanism isn't set. This should only happen when authentication mechanism is set to 'none'.
+        else {
+          console.log('No authentication set');
+          authenticationPassed = true;
+        }
 
-      return authenticationPassed;
+        return authenticationPassed;
+      }
+      else {
+        return null;
+      }
     }
   },
   computed: {
@@ -219,32 +255,36 @@ export default {
     },
   },
   async mounted() {
-    this.headers['X-Plex-Platform'] = this.sBrowser;
-    const { data } = await axios.create().post('https://plex.tv/api/v2/pins?strong=true', {}, { headers: { ...this.headers } });
-    this.code = data.code;
-    this.ticker = setInterval(async () => {
-      const result = await axios(`https://plex.tv/api/v2/pins/${data.id}`, {
-        headers: { ...this.headers },
-      });
-      if (result && result.data && result.data.authToken) {
-        if (this.openedWindow) {
-          this.openedWindow.close();
-        }
-        let authenticated = await this.checkAuth(result.data.authToken);
-        if(authenticated) {
-          window.localStorage.setItem('plexuser', JSON.stringify({ authToken: result.data.authToken }));
-          await this.$store.dispatch('PLEX_LOGIN_TOKEN', result.data.authToken);
-          this.token = result.data.authToken;
-          this.ready = true;
+    let authToken = null
+    // Check for PlexToken set via SyncLounge or Plex
+    if(window.localStorage.getItem('myPlexAccessToken')) {
+      authToken = window.localStorage.getItem('myPlexAccessToken');
+    }
 
-          this.letsGo();
+    if(authToken) {
+      this.ticker = setInterval(async () => {
+        try {
+          let authenticated = await this.checkAuth(authToken);
+          if(authenticated != null) {
+            if(authenticated == true) {
+              await this.setAuth(authToken);
+              this.letsGo();
+            }
+            else {
+              this.authError = `You are not authorized to access this server.`;
+            }
+            this.preAuth = true;
+            clearInterval(this.ticker);
+          }
         }
-        else {
-          this.authError = `You are not authorized to access this server.`;
+        catch(e) {
+
         }
-        clearInterval(this.ticker);
-      }
-    }, 2000);
+      }, 2000);
+    }
+    else {
+      this.preAuth = true;
+    }
   },
 };
 </script>

--- a/src/store.js
+++ b/src/store.js
@@ -99,6 +99,9 @@ const mutations = {
   SET_PLEX(state, value) {
     state.plex = value;
   },
+  SET_AUTHENTICATION(state, value) {
+    state.authentication = value;
+  },
   SET_AUTOJOIN(state, value) {
     state.autoJoin = value;
   },

--- a/src/store/modules/plex/actions.js
+++ b/src/store/modules/plex/actions.js
@@ -246,4 +246,26 @@ export default {
     console.log('Updating timeline for', client, 'with', timeline);
   },
 
+  PLEX_GET_SERVERS: ({ state, commit, dispatch }, token) => new Promise((resolve, reject) => {
+    if (!state.user) {
+      return reject(new Error('Sign in before getting devices'));
+    }
+
+    const options = PlexAuth.getApiOptions('https://plex.tv/pms/servers.xml', token, 5000, 'GET');
+    request(options, (error, response, body) => {
+      if (!error && response.statusCode === 200) {
+        // Valid response
+        parseXMLString(body, async (err, result) => {
+          if (err) {
+            return reject(err);
+          }
+          // Save the servers list associated with the logged in account
+          state.user.servers = result.MediaContainer.Server;
+          return resolve(true);
+        });
+      }
+      return reject(error);
+    });
+  }),
+
 };


### PR DESCRIPTION
This provides an authentication mechanism for users that set up their own SyncLounge.

### Settings

To set this, the following setting and format is used
```json
"authentication": {
    "mechanism": "plex",
    "type": ["server", "user"],
    "authorized": [
      "PLEX_SERVER_MACHINE_ID",
      "PLEX_USER_EMAIL",
      "PLEX_USER_NAME",
    ]
  }
```

- `mechanism` specifies how SyncLounge should authenticate a user. This is mostly for future-proofing to allow other authentication mechanisms to be provided. Defaults to `none`.
- `type` is mechanism dependent. Since `plex` is the only one currently, either or both `server` and `user` can be specified.
  - `server` checks against the plex server machine ID (`PLEX_SERVER_MACHINE_ID`). If the user has access to a server matching any of the IDs in the `authorized` list, they will be granted access.
  - `user` checks against the user's email (`PLEX_USER_EMAIL`) or username (`PLEX_USER_NAME`). If either matches a value in the `authorized` list, they will be granted access.
- `authorized` is a list of information for who is authorized.

### Authentication error/failure

While I didn't spend a lot of time trying to figure it out, I couldn't get the error message in App.vue to show on authentication error. Instead, I made it so that if authentication fails, the "Click Me" button will be replaced with a not authorized message as seen below.
![image](https://user-images.githubusercontent.com/1524443/76653937-29b10200-6540-11ea-8b2f-ffb2ce2fcff4.png)

### Sign-in changes
The sign-in logic flow is changed as well.
- Move Plex Pin Code retrieval and checking to happen when the popup is made.
  I was running into a bug sporadically where if the tab was open too long, you would have to refresh the page to authenticate. This fixes that by having that code only run when `openPopup` is called.

The following are mostly to help with SSO. If the right conditions are met, then the user will be logged in without having to go through Plex OAuth.
So far, I have only tested this with Organizr, but it works!
- Change `code` to `preAuth` in Vue
- Break out common code to `setAuth`
- Add a check to `checkAuth` to make sure `authentication` is set
- Do a pre-auth check when mounted

### Related

This was built upon PR https://github.com/samcm/synclounge/pull/136, which should be merged before this.