### PR TITLE
Add a dialog to disable popup blocking

### DIFF
--- a/src/components/signin.vue
+++ b/src/components/signin.vue
@@ -47,6 +47,14 @@
           </v-layout>
         </div>
       </v-card>
+      <v-dialog v-model="popupBlockerDialog" max-width="650px" :onClose="() => this.popupBlockerDialog = false">
+        <v-card style="background-color: #151924" class="pa-3">
+          <div class="text-xs-center">
+            It appears that your browser is blocking popups.<br />
+            Please enable popups for this site and try again.
+          </div>
+      </v-card>
+      </v-dialog>
     </v-flex>
   </v-layout>
 </template>
@@ -75,6 +83,7 @@ export default {
       ready: false,
       openedWindow: null,
       authError: null,
+      popupBlockerDialog: false,
     };
   },
   methods: {
@@ -119,11 +128,17 @@ export default {
         newWindow = window.open(this.url, '_blank');
       }
 
-      // Puts focus on the newWindow
-      if (window.focus) {
-        newWindow.focus();
+      if (!newWindow) {
+        clearInterval(this.ticker);
+        this.popupBlockerDialog = true;
       }
-      this.openedWindow = newWindow;
+      else {
+        // Puts focus on the newWindow
+        if (window.focus) {
+          newWindow.focus();
+        }
+        this.openedWindow = newWindow;
+      }
     },
     async setAuth(authToken) {
       window.localStorage.setItem('plexuser', JSON.stringify({ authToken: authToken }));


### PR DESCRIPTION
Fix for issue https://github.com/samcm/synclounge/issues/155

If SyncLounge fails to open the popup or new window, it will display a popup dialog (that could probably use a bit of styling fitness, but it works!).

![image](https://user-images.githubusercontent.com/1524443/77598932-8c5bb380-6ed9-11ea-948b-2849f3d4df1b.png)
