### PR TITLE
Update OAuth to work on different sub-domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10729,6 +10729,11 @@
         "clipboard": "^1.7.1"
       }
     },
+    "vue-cookies": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vue-cookies/-/vue-cookies-1.7.0.tgz",
+      "integrity": "sha512-vuEUm6wYMMrFAHFCrkzIUAy8+MgPAbBGmYXnk2M6X6O2KHbMT1wuDD2izacmsSUp6ZM02e23MJRtPRobl88VMg=="
+    },
     "vue-eslint-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "string-similarity": "^1.2.0",
     "videojs-contrib-hls": "^5.15.0",
     "vue": "^2.6.10",
+    "vue-cookies": "^1.7.0",
     "vue-router": "^2.3.1",
     "vuetify": "^1.5.14",
     "vuex": "^2.3.1",

--- a/src/components/signin.vue
+++ b/src/components/signin.vue
@@ -261,6 +261,9 @@ export default {
     if(window.localStorage.getItem('myPlexAccessToken')) {
       authToken = window.localStorage.getItem('myPlexAccessToken');
     }
+    else if($cookies.get('mpt')) {
+      authToken = $cookies.get('mpt');
+    }
 
     if(authToken) {
       this.ticker = setInterval(async () => {

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import { ObserveVisibility } from 'vue-observe-visibility/dist/vue-observe-visib
 import VueVideoPlayer from 'vue-video-player';
 import VueResource from 'vue-resource';
 import VueClipboards from 'vue-clipboards';
+import VueCookies from 'vue-cookies'
 
 import App from './App';
 import router from './router';
@@ -31,6 +32,10 @@ Vue.use(Vuetify, {
   },
 });
 Vue.config.productionTip = false;
+
+Vue.use(VueCookies);
+// set default config
+Vue.$cookies.config('7d');
 
 function nolog() {}
 


### PR DESCRIPTION
Update for https://github.com/samcm/synclounge/issues/168 and https://github.com/causefx/Organizr/issues/1344. 

Changes:
- Added vue-cookies library
- Added the import and things to main.js
- Added the check for the cookie to sign-in.vue
