### PR TITLE
sidebar updates

### DIFF
--- a/src/sidebar.vue
+++ b/src/sidebar.vue
@@ -5,10 +5,10 @@
         <v-flex xs12>
           <v-layout row wrap justify-space-between="" align-center>
             <v-flex xs8 offset-xs2 class="text-xs-center">
-              <h3 class="mb-0 pb-0 pa-0"> Room {{ ptRoom }}</h3>
+              <h3 class="mb-0 pb-0 pa-0"> Room: {{ ptRoom }}</h3>
             </v-flex>
             <v-flex xs2>
-              <v-menu>
+              <v-menu :offset-y="true">
                 <v-btn icon slot="activator" class="ma-0 pa-0" dark>
                   <v-icon>more_vert</v-icon>
                 </v-btn>
@@ -18,6 +18,13 @@
                   </v-list-tile>
                 </v-list>
               </v-menu>
+            </v-flex>
+          </v-layout>
+        </v-flex>
+        <v-flex xs12>
+          <v-layout row wrap justify-space-between="" align-center>
+            <v-flex xs8 offset-xs2 class="text-xs-center" v-if="me.role !== 'host' && this.$route.path.indexOf('/player') === -1">
+              <span class="mb-0 pb-0 pa-0"> Waiting for the host to start</span>
             </v-flex>
           </v-layout>
         </v-flex>
@@ -79,8 +86,21 @@
                   </span>
                 </v-tooltip>
               </v-list-tile-content>
-              <v-list-tile-action  v-if="isHost(user)">
-                <v-icon v-if="isHost(user)" style="color: #E5A00D">star</v-icon>
+              <v-list-tile-action>
+                <v-tooltip bottom color="light-blue darken-4" multi-line class="userlist">
+                  <v-icon v-if="isHost(user)" style="color: #E5A00D" slot="activator">star</v-icon>
+                  Host
+                </v-tooltip>
+                <v-menu v-if="user.uuid !== me.uuid && isHost(me)" :offset-y="true">
+                    <v-btn icon slot="activator" class="ma-0 pa-0" dark>
+                      <v-icon>more_vert</v-icon>
+                    </v-btn>
+                  <v-list>
+                    <v-list-tile @click="transferHost(user.username)">
+                      <v-list-tile-title>Make Host</v-list-tile-title>
+                    </v-list-tile>
+                  </v-list>
+                </v-menu>
               </v-list-tile-action>
             </v-list-tile>
           <div class="pl-2 pr-2 pt-2 mt-0 pb-0 mb-0">


### PR DESCRIPTION
- Add colon before room name
   ![image](https://user-images.githubusercontent.com/1524443/78708732-966db100-78e0-11ea-9536-ec623ee18966.png)
- Add a banner at the top of the sidebar for guests
   ![image](https://user-images.githubusercontent.com/1524443/78708778-a7b6bd80-78e0-11ea-9d02-2a6bfc45f50f.png)
- Add menu for each guest for actions
   ![image](https://user-images.githubusercontent.com/1524443/78708857-c3ba5f00-78e0-11ea-81c8-83bb293761aa.png)
- Add "Make Host" action
   ![image](https://user-images.githubusercontent.com/1524443/78708897-d3d23e80-78e0-11ea-985c-ca927204f1b4.png)
- Offset menu options to prevent accidental clicks on menu items
   ![image](https://user-images.githubusercontent.com/1524443/78708957-e9476880-78e0-11ea-839c-a03ead0f0a6a.png)
   ![image](https://user-images.githubusercontent.com/1524443/78708897-d3d23e80-78e0-11ea-985c-ca927204f1b4.png)