### PR TITLE
Add workflow to mark issues/PRs stale then close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
+          stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
+          stale-issue-label: "no-issue-activity"
+          exempt-issue-label: 'keep-open'
+          stale-pr-label: "no-pr-activity"
+          exempt-pr-label: 'keep-open'
+          days-before-stale: 60
+          days-before-close: 7


### PR DESCRIPTION
This will run at midnight (GitHub server time) to mark Issues or PRs as stale after 60 days of no activity and close them 7 days after that.

Issues/PRs can be ignored by this by adding the label `keep-open` to them if needed.