### PR TITLE
Always force signin if the user hasn't authenticated with Plex

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -354,9 +354,7 @@ export default {
       this.$store.dispatch('PLAYBACK_CHANGE', data);
     });
     if (!window.localStorage.getItem('plexuser')) {
-      if (this.$route.fullPath.indexOf('join') === -1) {
-        this.$router.push('/signin');
-      }
+      this.$router.push('/signin');
       this.loading = false;
       return;
     }


### PR DESCRIPTION
A random edge case that was discovered by accident. A user is able to go to the `/joinroom` route without being authenticated via Plex. Not a huge issue since nothing can be done from there but just in case.