### PR TITLE
Stringify authentication's default value

### DIFF
--- a/SettingsHelper.js
+++ b/SettingsHelper.js
@@ -168,7 +168,7 @@ module.exports = function () {
       output[setting.local] = setting.default;
       console.log(`- Done.`);
     }
-    process.env[setting.env] = output[setting.local];
+    process.env[setting.env] = typeof output[setting.local] === 'object' ? JSON.stringify(output[setting.local]) : output[setting.local];
   }
   //console.log('Our settings are', output)
   return output;

--- a/SettingsHelper.js
+++ b/SettingsHelper.js
@@ -43,9 +43,9 @@ module.exports = function () {
     {
       local: 'authentication',
       env: 'AUTHENTICATION',
-      default: JSON.stringify({
+      default: {
         mechanism: 'none'
-      })
+      }
     },
     {
       local: 'customServer',

--- a/SettingsHelper.js
+++ b/SettingsHelper.js
@@ -43,9 +43,9 @@ module.exports = function () {
     {
       local: 'authentication',
       env: 'AUTHENTICATION',
-      default: {
+      default: JSON.stringify({
         mechanism: 'none'
-      }
+      })
     },
     {
       local: 'customServer',


### PR DESCRIPTION
This solves the issue mentioned in https://github.com/Starbix/docker-synclounge/issues/13#issue-601644724

```
ErrorWarningSystemArrayLogin


sh: : unknown operand
Rebuilding Webapp for custom options support. This can take a minute or two.
npm WARN SyncLounge@2.0.0 No repository field.
npm WARN SyncLounge@2.0.0 No license field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.2 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

audited 11620 packages in 8.946s
found 623 vulnerabilities (159 low, 17 moderate, 447 high)
run `npm audit fix` to fix them, or `npm audit` for details

> SyncLounge@2.0.0 build /opt/synclounge
> node build/build.js

authentication/AUTHENTICATION must be a JSON object. Attempting to convert it for you.
- Unable to parse '[object Object]'
- Please check your syntax. Reverting to default.
- Done.
Production settings {
webroot: '',
webapp_port: '8088',
accessUrl: '',
autoJoin: 'true',
autoJoinServer: 'https://<domain here>.com/slserver',
autoJoinRoom: '',
autoJoinPassword: '',
authentication: '[object Object]',
customServer: '',
servers: '',
serverroot: '/slserver',
server_port: '8089'
}
```