### PR TITLE
Autoplay if rawTitle doesn't match

### DIFF
--- a/src/store/modules/synclounge.js
+++ b/src/store/modules/synclounge.js
@@ -306,7 +306,7 @@ export default {
                     // Check if we need to autoplay
                     if (
                       (ourTimeline.state === 'stopped' || !ourTimeline.state) &&
-                      hostTimeline.playerState !== 'stopped'
+                      hostTimeline.playerState !== 'stopped' || rootState.rawTitle !== hostTimeline.rawTitle
                     ) {
                       if (rootState.blockAutoPlay || !hostTimeline.rawTitle) {
                         return resolve();
@@ -327,6 +327,7 @@ export default {
                         });
                       }
 
+                      rootState.rawTitle = hostTimeline.rawTitle;
                       sendNotification(`Searching Plex Servers for "${hostTimeline.rawTitle}"`);
                       const result = await rootState.chosenClient
                         .playContentAutomatically(


### PR DESCRIPTION
Autoplay if rawTitle sent from host doesn't match the rawTitle the host sent last time an autoplay was done. This fixes an issue where clients weren't properly switching to the next episode when the host let the next episode play with the "upnext" autoplay.