### PR TITLE
Keep spot when changing quality

### DIFF
--- a/src/components/application/ptplayer.vue
+++ b/src/components/application/ptplayer.vue
@@ -638,6 +638,11 @@ export default {
         return;
       }
 
+      if (!changeItem) {
+        // Update offset to current time to resume where we were
+        this.offset = this.playertime;
+      }
+
       const req = () => {
         this.sources = this.generateSources();
         request(this.getSourceByLabel(this.chosenQuality).initUrl, (error, response, body) => {
@@ -766,6 +771,7 @@ export default {
         session: this.sessionId,
         offset: 0,
         // offset: Math.round(this.playertime / 1000),
+        time: Math.round(this.playertime / 1000),
         subtitles: 'burn',
         copyts: 1,
         'Accept-Language': 'en',

--- a/src/components/application/ptplayer/videoplayer.vue
+++ b/src/components/application/ptplayer/videoplayer.vue
@@ -316,9 +316,6 @@ export default {
     },
     onPlayerLoadeddata(player) {
       const that = this;
-      this.$nextTick(() => {
-        this.player.currentTime(this.initialOffset / 1000);
-      });
 
       player.on(['pause'], () => {
         this.isPlaying = 'paused';
@@ -425,6 +422,7 @@ export default {
     playerReadied(player) {
       // console.log('Setting volume to ' + this.$store.getters.getSettingPTPLAYERVOLUME )
       this.player.volume(this.$store.getters.getSettings.PTPLAYERVOLUME || 0);
+      this.player.currentTime(this.initialOffset / 1000);
     },
 
   },


### PR DESCRIPTION
The web player will now keep its place when changing qualities, audio tracks, and subtitles. 

The web player will also now not always load the first segment when resuming/starting from the middle of a video.