### PR TITLE
Default web play volume 100%

### DIFF
--- a/src/components/application/ptplayer/videoplayer.vue
+++ b/src/components/application/ptplayer/videoplayer.vue
@@ -147,7 +147,7 @@ export default {
 
         fluid: true,
         preload: 'auto',
-        volume: 0.5,
+        volume: 1,
         aspectRatio: '16:9',
         autoplay: true,
         width: '100%',
@@ -424,7 +424,7 @@ export default {
     },
     playerReadied(player) {
       // console.log('Setting volume to ' + this.$store.getters.getSettingPTPLAYERVOLUME )
-      this.player.volume(this.$store.getters.getSettings.PTPLAYERVOLUME || 0);
+      this.player.volume(this.$store.getters.getSettings.PTPLAYERVOLUME || 100);
     },
 
   },


### PR DESCRIPTION
Current behavior is that volume is set to 0% when initially loading the app. This appears to have been done to give the player the best chance at autoplaying, however, the caution is unneeded. videojs describes [some suggestions](https://blog.videojs.com/autoplay-best-practices-with-video-js/) in dealing with autoplay and also links to policies of the major browsers.

In chrome, if the user has interacted with the domain (clicked) then autoplay with sound is enabled. Since a user always has to login to the app with Plex, this criteria is always met for chrome, along with selecting the player.

Additionally, the previous behavior of just setting the volume to 0 isn't enough and should have actually set the mute attribute instead to make it have the best chance. 

Finally, if autoplay does ever fail, videojs will just display the play icon and users can easily press play and everything will work fine.